### PR TITLE
Nette 3.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
 	"license": "MIT",
 	"require-dev": {
 		"php": "~7.1",
-		"nette/security": "~2.4",
-		"nette/di": "~2.4",
+		"nette/security": "~3.0",
+		"nette/di": "~3.0",
 		"nette/tester": "~2.0",
 		"phpstan/phpstan": "^0.8.5",
 		"zendframework/zend-permissions-acl": "^2.6"

--- a/src/Bridges/NetteDI/AuthorizationExtension.php
+++ b/src/Bridges/NetteDI/AuthorizationExtension.php
@@ -30,14 +30,14 @@ class AuthorizationExtension extends CompilerExtension
 		$builder = $this->getContainerBuilder();
 		$config = $this->validateConfig($this->defaults);
 		$builder->addDefinition($this->prefix('authorizator'))
-			->setClass(Authorizator::class)
+			->setType(Authorizator::class)
 			->setFactory(DefaultAuthorizator::class);
 
 
 		if ($config['accessEvaluator'] !== NULL) {
-			$def = $builder->addDefinition('accessEvaluator')
-				->setClass(AccessEvaluator::class);
-			Compiler::loadDefinition($def, $config['accessEvaluator']);
+			$builder->addDefinition('accessEvaluator')
+				->setType(AccessEvaluator::class)
+				->setFactory($config['accessEvaluator']);
 		}
 	}
 


### PR DESCRIPTION
This technically restricts what can be passed as `accessEvaluator` but I hope 99% of use cases should still be covered and any more complex access evaluator can be passed as a reference to another configured service.